### PR TITLE
Update ordered_set.py

### DIFF
--- a/jet/ordered_set.py
+++ b/jet/ordered_set.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc as collections
 
 
 class OrderedSet(collections.MutableSet):


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated